### PR TITLE
Disable TopDesk printer driver loading, because it is corrupting the …

### DIFF
--- a/topdesk/Main/DeskTop.sub7.s
+++ b/topdesk/Main/DeskTop.sub7.s
@@ -370,7 +370,7 @@ StartUp:
 	beq	@40
 	LoadB	r1L,0
 	LoadW___	r6,Name
-	jsr	NewGetFile
+	;jsr	NewGetFile
 @40:	LoadB	firstBoot,$ff
 	jsr	SetCopyMemLow
 	ldy	#0

--- a/topdesk/topdesk65.grc
+++ b/topdesk/topdesk65.grc
@@ -8,6 +8,6 @@ HEADER APPLICATION "65 DESKTOP" "TopDesk65" "V6.0" {
 }
 
 MEMORY {
-    overlaysize 0x9e7
+    overlaysize 0x971
     overlaynums 0 1 2 3 4 5 6 7 8 9 10
 }


### PR DESCRIPTION
…loaded modules but it not used anyhow. #30